### PR TITLE
Allow action to return any type and an anyhow error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +140,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 name = "cbadv"
 version = "2.0.2"
 dependencies = [
+ "anyhow",
  "assert-json-diff",
  "base64",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ uuid = { version = "1.11.0", features = ["v4", "fast-rng"] }
 base64 = "0.22.1"
 ring = "0.17.8"
 openssl = "0.10.68"
+anyhow = "1.0.95"
 
 [[example]]
 name = "account_api"

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -14,29 +14,23 @@ use cbadv::types::CbResult;
 use cbadv::WebSocketClientBuilder;
 
 /// This is used to parse messages. It is passed to the `listen` function to pull Messages out of
-/// the stream.
-fn message_action(msg: CbResult<Message>) -> Result<(), String> {
-    let rcvd = match msg {
-        Ok(Message {
+/// the stream. You can do something with each message or return part of it that you want to work
+/// with later.
+fn message_action(msg: CbResult<Message>) -> anyhow::Result<Channel> {
+    // let's turn the CbResult into an anyhow::Result
+    match msg? {
+        Message {
             events: Events::Candles(candles_events),
             channel,
             ..
-        }) => {
+        } => {
             for ticker in candles_events {
                 println!("{ticker:?}");
             }
-            format!("this is a {channel:?} message")
+            Ok(channel)
         }
-        Ok(message) => format!(
-            "this is not a candles message it is a {:?} message",
-            message.channel
-        ), // Leverage Debug for all Message variants
-        Err(error) => format!("Error: {error}"), // Handle WebSocket errors
-    };
-
-    // Update the callback object's properties and log the message.
-    println!("{rcvd}\n");
-    Ok(())
+        message => Ok(message.channel), // Leverage Debug for all Message variants
+    }
 }
 
 #[tokio::main]
@@ -87,11 +81,22 @@ async fn main() {
 
     loop {
         // Fetch messages from the WebSocket stream.
-        let _ = client.fetch_sync(&mut stream, 100, |msg| {
+        let fetched = client.fetch_sync(&mut stream, 100, |msg| {
             count += 1;
             print!("{count}: ");
             message_action(msg)
         });
+
+        match fetched {
+            Ok(results) => {
+                for channel in results {
+                    println!("{channel:?}");
+                }
+            }
+            Err(e) => {
+                eprintln!("Do something with: {e}");
+            }
+        }
 
         // Calculate the time since the last tick and sleep for the remaining time to hit the tick rate.
         let last_tick_ms = last_tick.elapsed().as_millis();

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -8,6 +8,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use anyhow::Result as AnyhowResult;
 use futures::stream::{SplitSink, Stream};
 use futures::task::{noop_waker_ref, Context, Poll};
 use futures::{SinkExt, StreamExt};
@@ -444,24 +445,26 @@ impl WebSocketClient {
     /// # Errors
     ///
     /// Returns a `String` if the user returns an error within the action.
-    pub fn fetch_sync<F>(
+    pub fn fetch_sync<F, U>(
         &self,
         stream: &mut EndpointStream,
         limit: usize,
         mut action: F,
-    ) -> Result<(), String>
+    ) -> AnyhowResult<Vec<U>>
     where
-        F: FnMut(CbResult<Message>) -> Result<(), String>,
+        F: FnMut(CbResult<Message>) -> AnyhowResult<U>,
     {
         let mut count = 0;
+        let mut res: Vec<U> = Vec::new();
 
         while count <= limit || limit == usize::MAX {
             // Use poll_next to check for available messages without waiting.
             match Pin::new(&mut *stream).poll_next(&mut Context::from_waker(noop_waker_ref())) {
                 Poll::Ready(Some(message)) => {
                     // Process and add the message to the result vector if valid.
-                    if let Some(result) = Self::process_message(message) {
-                        action(result)?;
+                    if let Some(received) = Self::process_message(message) {
+                        let item = action(received)?;
+                        res.push(item);
                     }
 
                     count += 1;
@@ -473,7 +476,7 @@ impl WebSocketClient {
             }
         }
 
-        Ok(())
+        Ok(res)
     }
 
     /// Asynchronously fetches messages from the WebSocket stream with a limit on the number of messages to fetch.
@@ -489,17 +492,18 @@ impl WebSocketClient {
     /// # Errors
     ///
     /// Returns a `String` if the user returns an error within the action.
-    pub async fn fetch_async<F, Fut>(
+    pub async fn fetch_async<F, U, Fut>(
         &self,
         stream: &mut EndpointStream,
         limit: usize,
         mut action: F,
-    ) -> Result<(), String>
+    ) -> AnyhowResult<Vec<U>>
     where
         F: FnMut(CbResult<Message>) -> Fut,
-        Fut: Future<Output = Result<(), String>>,
+        Fut: Future<Output = AnyhowResult<U>>,
     {
         let mut count = 0;
+        let mut res: Vec<U> = Vec::new();
 
         while count <= limit || limit == usize::MAX {
             // Use poll_next to check for available messages without waiting.
@@ -507,7 +511,8 @@ impl WebSocketClient {
                 Poll::Ready(Some(message)) => {
                     // Process and add the message to the result vector if valid.
                     if let Some(result) = Self::process_message(message) {
-                        action(result).await?;
+                        let item = action(result).await?;
+                        res.push(item);
                     }
 
                     count += 1;
@@ -519,7 +524,7 @@ impl WebSocketClient {
             }
         }
 
-        Ok(())
+        Ok(res)
     }
 
     /// Waits for a token to be consumable for the correct bucket.


### PR DESCRIPTION
One more...

This allows the message action to return a vector of any type and an anyhow error (could also use Box<Error> if you prefer).  It's nice because it could be that someone wants to do something in a batch operation as opposed to a per message operation.  Also I found the `Result<(), String>`  to not idiomatic for returning an error. 